### PR TITLE
DSND-2940: Finish GET ACSP full profile error handling

### DIFF
--- a/src/main/java/uk/gov/companieshouse/acspprofile/api/config/WebConfig.java
+++ b/src/main/java/uk/gov/companieshouse/acspprofile/api/config/WebConfig.java
@@ -10,6 +10,8 @@ import uk.gov.companieshouse.acspprofile.api.auth.FullProfileAuthInterceptor;
 class WebConfig implements WebMvcConfigurer {
 
     private static final String FULL_PROFILE_PATH = "/**/full-profile";
+    private static final String ERROR_PATH = "/error"; // NOSONAR
+
     private final AuthInterceptor authInterceptor;
     private final FullProfileAuthInterceptor fullProfileAuthInterceptor;
 
@@ -21,8 +23,9 @@ class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
-                .excludePathPatterns(FULL_PROFILE_PATH);
+                .excludePathPatterns(FULL_PROFILE_PATH, ERROR_PATH);
         registry.addInterceptor(fullProfileAuthInterceptor)
-                .addPathPatterns(FULL_PROFILE_PATH);
+                .addPathPatterns(FULL_PROFILE_PATH)
+                .excludePathPatterns(ERROR_PATH);
     }
 }


### PR DESCRIPTION
## Describe the changes
* Fixed a bug where an error thrown during full profile get would return 403 forbidden.
* Added more unsuccessful iTests.

### Related Jira tickets

[DSND-2940](https://companieshouse.atlassian.net/browse/DSND-2940)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-2940]: https://companieshouse.atlassian.net/browse/DSND-2940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ