### PR TITLE
ASM-1074: Spring Boot 4 upgrade and CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,22 +19,21 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <spring.boot.version>3.5.10</spring.boot.version>
+    <spring.boot.version>4.0.6</spring.boot.version>
 
     <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
     <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
     <wiremock.version>3.13.2</wiremock.version>
-    <opentelemetry-instrumentation-bom.version>2.24.0</opentelemetry-instrumentation-bom.version>
-    <commons-lang3.version>3.20.0</commons-lang3.version>
+    <opentelemetry-instrumentation-bom.version>2.27.0</opentelemetry-instrumentation-bom.version>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
 
     <skip.unit.tests>false</skip.unit.tests>
     <skip.integration.tests>false</skip.integration.tests>
 
-    <structured-logging.version>3.0.48</structured-logging.version>
-    <api-sdk-manager-java-library.version>3.0.15</api-sdk-manager-java-library.version>
-    <private-api-sdk-java.version>4.0.448</private-api-sdk-java.version>
+    <structured-logging.version>3.0.57</structured-logging.version>
+    <api-sdk-manager-java-library.version>3.0.22</api-sdk-manager-java-library.version>
+    <private-api-sdk-java.version>6.0.10</private-api-sdk-java.version>
 
     <!--sonar configuration-->
     <sonar.coverage.jacoco.xmlReportPaths>
@@ -86,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-aop</artifactId>
+      <artifactId>spring-boot-starter-aspectj</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -116,7 +115,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>${commons-lang3.version}</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.companieshouse</groupId>
@@ -146,14 +144,30 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webmvc-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.20.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>mongodb</artifactId>
+      <artifactId>testcontainers-mongodb</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -164,7 +178,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,9 +3,9 @@ management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.health=healthcheck
 management.endpoint.health.show-details=never
 management.endpoint.health.enabled=true
-management.health.mongo.enabled=false
+management.health.mongodb.enabled=false
 
-spring.data.mongodb.uri=${MONGODB_URL:mongodb://mongo:27017/acsp_profile}
-spring.data.mongodb.name=acsp_profile
+spring.mongodb.uri=${MONGODB_URL:mongodb://mongo:27017/acsp_profile}
+spring.mongodb.name=acsp_profile
 
 server.port=${PORT:8081}

--- a/src/test/java/uk/gov/companieshouse/acspprofile/api/AcspProfileApplicationIT.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/api/AcspProfileApplicationIT.java
@@ -3,13 +3,13 @@ package uk.gov.companieshouse.acspprofile.api;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
@@ -32,6 +32,6 @@ class AcspProfileApplicationIT {
         this.mockMvc.perform(get("/healthcheck"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().string("{\"status\":\"UP\"}"));
+                .andExpect(jsonPath("$.status").value("UP"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/acspprofile/api/controller/AbstractControllerIT.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/api/controller/AbstractControllerIT.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 import uk.gov.companieshouse.api.acspprofile.InternalAcspApi;
 
 @AutoConfigureMockMvc

--- a/src/test/java/uk/gov/companieshouse/acspprofile/api/controller/ControllerIT.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/api/controller/ControllerIT.java
@@ -22,17 +22,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 import uk.gov.companieshouse.acspprofile.api.mapper.InstantSupplier;
 import uk.gov.companieshouse.acspprofile.api.model.AcspProfileDocument;
 import uk.gov.companieshouse.api.acspprofile.AcspFullProfile;
@@ -52,6 +51,7 @@ class ControllerIT extends AbstractControllerIT {
     private static final String LIMITED_COMPANY_TYPE = "limited-company";
 
     @Container
+    @ServiceConnection
     private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5.0.12");
 
     @Autowired
@@ -59,11 +59,6 @@ class ControllerIT extends AbstractControllerIT {
 
     @MockitoBean
     private InstantSupplier instantSupplier;
-
-    @DynamicPropertySource
-    static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
-    }
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/uk/gov/companieshouse/acspprofile/api/mapper/AcspRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/api/mapper/AcspRequestMapperTest.java
@@ -145,7 +145,7 @@ class AcspRequestMapperTest {
         verify(addressMapper).mapAddressRequest(address);
         verify(addressMapper).mapAddressRequest(null);
         verify(soleTraderDetailsMapper).mapSoleTraderDetailsRequest(null);
-        verify(amlDetailsMapper).mapAmlDetailsRequest(null);
+        verify(amlDetailsMapper).mapAmlDetailsRequest(List.of());
     }
 
     @Test
@@ -180,7 +180,7 @@ class AcspRequestMapperTest {
         verify(addressMapper).mapAddressRequest(address);
         verify(addressMapper).mapAddressRequest(null);
         verify(soleTraderDetailsMapper).mapSoleTraderDetailsRequest(null);
-        verify(amlDetailsMapper).mapAmlDetailsRequest(null);
+        verify(amlDetailsMapper).mapAmlDetailsRequest(List.of());
     }
 
     private InternalAcspApi getInternalAcspRequest(AcspFullProfile acspFullProfile, String updatedBy) {

--- a/src/test/java/uk/gov/companieshouse/acspprofile/api/mapper/AcspResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/api/mapper/AcspResponseMapperTest.java
@@ -187,6 +187,7 @@ class AcspResponseMapperTest {
                 .kind(FULL_PROFILE_KIND)
                 .notifiedFrom(NOTIFIED_FROM)
                 .registeredOfficeAddress(expectedAddress)
+                .amlDetails(null)
                 .email(EMAIL)
                 .links(new Links()
                         .self(SELF_LINK));

--- a/src/test/java/uk/gov/companieshouse/acspprofile/api/repository/AcspMongoRepositoryIT.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/api/repository/AcspMongoRepositoryIT.java
@@ -17,13 +17,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 import uk.gov.companieshouse.acspprofile.api.exception.BadGatewayException;
 import uk.gov.companieshouse.acspprofile.api.model.AcspProfileDocument;
 
@@ -32,6 +31,7 @@ import uk.gov.companieshouse.acspprofile.api.model.AcspProfileDocument;
 class AcspMongoRepositoryIT {
 
     @Container
+    @ServiceConnection
     private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5.0.12");
     private static final String ACSP_PROFILE_COLLECTION = "acsp_profile";
     private static final String ACSP_NUMBER = "AP123456";
@@ -44,11 +44,6 @@ class AcspMongoRepositoryIT {
     private MongoTemplate mongoTemplate;
     @Autowired
     private ObjectMapper objectMapper;
-
-    @DynamicPropertySource
-    static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
-    }
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
### Jira ticket

[ASM-1074](https://companieshouse.atlassian.net/browse/ASM-1074)

## Describe the changes

Upgrades to **Spring Boot 4.0.6** (Spring Framework 7, Tomcat 11,
`private-api-sdk-java` 6.0.10) and resolves the critical/high CVEs
flagged by Dependency Track against `spring-boot*`, `spring-*` 6.2.15
and `tomcat-embed-core` 10.1.50.

Mirrors the same upgrade applied to the sibling
[`acsp-profile-delta-consumer` PR #20](https://github.com/companieshouse/acsp-profile-delta-consumer/pull/20).

### Spring Boot 4 migration

| Change | Why |
| --- | --- |
| `spring.boot.version`: `3.5.10` → `4.0.6` | Ticket scope. Brings Spring Framework 7 and Tomcat 11. |
| Remove `spring-boot-starter-aop`; add `spring-boot-starter-aspectj` | Starter was deleted from the Boot 4 BOM. `spring-aop` still comes transitively via `spring-context`. |
| Rename testcontainers artifacts (`mongodb` → `testcontainers-mongodb`, `junit-jupiter` → `testcontainers-junit-jupiter`) | Testcontainers 2.x renamed every artifact with a `testcontainers-` prefix. |
| Add `spring-boot-starter-webmvc-test` | Boot 4 split webmvc test autoconfigure (MockMvc etc.) into its own starter; `spring-boot-starter-test` no longer pulls it in. |
| Move `AutoConfigureMockMvc` import to `org.springframework.boot.webmvc.test.autoconfigure` | Same module split — class relocated alongside the autoconfigure code. |
| `opentelemetry-instrumentation-bom`: `2.24.0` → `2.27.0` | Older versions fail `@Conditional` evaluation against Spring 7 at context init. SB4 / Framework 7 support landed in 2.19+. |
| Add explicit `commons-io:commons-io:2.20.0` (test scope) | The Boot 4 BOM no longer manages commons-io, and Testcontainers 2.x removed the shaded `org.apache.commons.io` vendoring used by three of our ITs. |
| Drop the explicit `commons-lang3` version | Boot 4 BOM now manages a fixed version. |
| `structured-logging` `3.0.48` → `3.0.57`, `api-sdk-manager-java-library` `3.0.15` → `3.0.22`, `private-api-sdk-java` `4.0.448` → `6.0.10` | Match versions in the sibling delta-consumer; needed for compatibility with the SDK request/response shapes the consumer hands us. |
| Relax `AcspProfileApplicationIT#shouldReturn200FromGetHealthEndpoint` to a JSONPath assertion on `$.status` | Robust against any future actuator body change in Boot 4. |
| Update `AcspRequestMapperTest` verify calls and `AcspResponseMapperTest` expected fixture | `private-api-sdk-java` 6 changes the default of `AcspFullProfile.amlDetails` from `null` to `[]`. |

### CVE fixes

All 14 CVEs from the ticket are resolved by the Spring Boot 4.0.6 BOM:

| Artifact | CVEs |
| --- | --- |
| `spring-boot-actuator-autoconfigure` | CVE-2026-40976 (Critical), CVE-2026-22731, CVE-2026-22733 |
| `tomcat-embed-core` | CVE-2026-24734, CVE-2026-34483, CVE-2026-25854 |
| `spring-boot` | CVE-2026-40975, CVE-2026-40973, CVE-2026-40977 |
| `spring-boot-autoconfigure` | CVE-2026-40971, CVE-2026-40974 |
| `spring-webmvc` | CVE-2026-22737 |
| `spring-core` | CVE-2026-22745 |
| `spring-web` | CVE-2026-22740 |

## Developer check list

### General
- [x] Is the PR as small as it can be?
- [x] Has the code been double-checked against `main`?
- [x] Has the `POM` been updated for the latest versions of dependencies?
- [x] Is the `README` up to date?
- [ ] Does the code adhere to standards in this repository, including SonarQube checks?
- [ ] Has the Jira ticket been updated with any relevant comments?

### Configuration
- [x] Are any configuration changes required in `docker-chs-development`? — None
- [x] Have new env vars been added to `ecs-service-configs-dev`? — None

### Testing
- [x] Do the code changes have unit and integration tests with code coverage > 80%?
- [x] Has the code been tested locally and/or passed the API Karate tests locally?
- [ ] Have mandatory manual test cases been run?

## Notes to the tester

`mvn clean verify` is green (74 unit + 32 IT tests).

Verified locally via `docker-chs-development`:

| Step | Result |
| --- | --- |
| Service startup | `Started AcspProfileApplication` on Spring Boot 4.0.6 / Spring 7.0.x, Mongo connected |
| Healthcheck | `GET /healthcheck` → `200 {"status":"UP"}` |
| PUT new ACSP | `200` + `Location: /authorised-corporate-service-providers/AP123456` |
| GET partial profile | `200`, sensitive fields (`email`, `aml_details`) omitted |
| GET full profile | `200`, `email` + `aml_details` populated |
| Stale-delta PUT | `409 Conflict` — the load-bearing `delta_at` versioning safety net still fires correctly under Boot 4 |


[ASM-1074]: https://companieshouse.atlassian.net/browse/ASM-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ