### PR TITLE
ASM-1074: fix ObjectMapper bean for Jackson 3 under Spring Boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,10 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <spring.boot.version>4.0.6</spring.boot.version>
+    <!-- Override the tomcat-embed-core version managed by the spring-boot-dependencies BOM
+         to fix CVE-2026-41293, CVE-2026-41284, CVE-2026-43513, CVE-2026-43512, CVE-2026-42498,
+         CVE-2026-43515. Drop once a Spring Boot 4.0.x patch bumps Tomcat for us. -->
+    <tomcat.version>11.0.22</tomcat.version>
 
     <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
     <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
@@ -58,6 +62,29 @@
         <version>${spring.boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <!-- Override every tomcat-embed-* artifact managed by spring-boot-dependencies
+           to fix CVE-2026-41293, CVE-2026-41284, CVE-2026-43513, CVE-2026-43512,
+           CVE-2026-42498, CVE-2026-43515. The CVEs apply to Tomcat itself, so every
+           tomcat-embed-* sibling is flagged at the same version. A <tomcat.version>
+           property override has no effect on imported BOMs (only on parent
+           inheritance), so each artifact must be pinned via an explicit
+           dependencyManagement entry. Drop once a Spring Boot 4.0.x patch bumps
+           Tomcat for us. -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${tomcat.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/uk/gov/companieshouse/acspprofile/api/config/AppConfig.java
+++ b/src/main/java/uk/gov/companieshouse/acspprofile/api/config/AppConfig.java
@@ -1,30 +1,28 @@
 package uk.gov.companieshouse.acspprofile.api.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.text.SimpleDateFormat;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 import uk.gov.companieshouse.acspprofile.api.serdes.EmptyFieldDeserializer;
 
 @Configuration
 public class AppConfig {
 
     @Bean
-    @Primary
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .setDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
-                .registerModule(new SimpleModule().addDeserializer(String.class,
+    public JsonMapper jacksonJsonMapper() {
+        return JsonMapper.builder()
+                .addModule(new SimpleModule().addDeserializer(String.class,
                         new EmptyFieldDeserializer()))
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .defaultDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
+                .changeDefaultPropertyInclusion(incl ->
+                        incl.withValueInclusion(JsonInclude.Include.NON_NULL))
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+                .build();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/acspprofile/api/serdes/EmptyFieldDeserializer.java
+++ b/src/main/java/uk/gov/companieshouse/acspprofile/api/serdes/EmptyFieldDeserializer.java
@@ -1,16 +1,14 @@
 package uk.gov.companieshouse.acspprofile.api.serdes;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
-public class EmptyFieldDeserializer extends JsonDeserializer<String> {
+public class EmptyFieldDeserializer extends ValueDeserializer<String> {
 
     @Override
-    public String deserialize(JsonParser jsonParser, DeserializationContext context)
-            throws IOException {
+    public String deserialize(JsonParser jsonParser, DeserializationContext context) {
         JsonNode node = jsonParser.readValueAsTree();
         String str = node.asText();
         if (str.isEmpty()) {

--- a/src/test/java/uk/gov/companieshouse/acspprofile/api/controller/AbstractControllerIT.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/api/controller/AbstractControllerIT.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.acspprofile.api.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/uk/gov/companieshouse/acspprofile/api/repository/AcspMongoRepositoryIT.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/api/repository/AcspMongoRepositoryIT.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;

--- a/src/test/java/uk/gov/companieshouse/acspprofile/api/serdes/EmptyFieldDeserializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/acspprofile/api/serdes/EmptyFieldDeserializerTest.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.acspprofile.api.serdes;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.acspprofile.api.config.AppConfig;
 
@@ -14,14 +14,14 @@ class EmptyFieldDeserializerTest {
                   "stuff": "stuff",
                   "optional_stuff": "",
                   "unknown_stuff": ""
-            },
+            }
             """;
 
     private record Stuff(String stuff, String optional_stuff) {
 
     }
 
-    private final ObjectMapper objectMapper = new AppConfig().objectMapper();
+    private final ObjectMapper objectMapper = new AppConfig().jacksonJsonMapper();
 
     @Test
     void successfullyDeserialize() throws Exception {


### PR DESCRIPTION
## Describe the changes

Follow-up to #27. Two issues caught only after the Spring Boot 4 upgrade went out to test:

### 1. `ObjectMapper` bean dropped on the floor by the HTTP message converter

Spring Boot 4 wires `tools.jackson.databind` (Jackson 3) into its HTTP message converter. The `@Primary com.fasterxml.jackson.databind.ObjectMapper` bean in `AppConfig` was silently ignored when serializing responses, dropping every customization the bean was applying:

- `JsonInclude.NON_NULL`
- `EmptyFieldDeserializer` (custom String deserializer)
- `SimpleDateFormat("yyyy-MM-dd")`
- `FAIL_ON_UNKNOWN_PROPERTIES = false`
- `FAIL_ON_EMPTY_BEANS = false`

The visible symptom flagged by the tester was `acsp_get_full_profile.feature` failing because GET responses now contained `deauthorised_from`, `etag`, `notified_from`, `sole_trader_details`, `aml_details`, `membership_details` as `null` keys that aren't in the expected karate match.

This didn't show up in `mvn verify` because the IT tests serialize/deserialize through the **input** request body, not the response. Only an end-to-end karate run against a running service surfaces it.

### 2. `tomcat-embed-*` 11.0.21 CVEs blocking the same pipeline

The dependency-check stage of the pipeline started failing this week against six CVEs (`CVE-2026-41293` 9.8, `CVE-2026-41284` 7.5, `CVE-2026-43513` 7.5, `CVE-2026-43512` 9.8, `CVE-2026-42498` 7.3, `CVE-2026-43515` 9.1) in `tomcat-embed-core:11.0.21` (and its `-el` / `-websocket` siblings, which the BOM manages at the same version), which the SB 4.0.6 BOM manages. There is no SB 4.0.x patch on Central yet (latest published is `4.1.0-RC1`). Tomcat 11.0.22 is published and clears all six. Bundling the override here because the same pipeline run blocks the Jackson fix on this gate.

### Changes

| Change | Why |
| --- | --- |
| Rebuild the ObjectMapper bean via `tools.jackson.databind.json.JsonMapper.builder()` and register it as `jacksonJsonMapper: JsonMapper` (no `@Primary`) | SB4 auto-registers a `@Primary JsonMapper` named `jacksonJsonMapper` — providing our own bean under the same name + type takes over via `@ConditionalOnMissingBean` without a duplicate-primary clash. |
| Port `EmptyFieldDeserializer` from `JsonDeserializer<String>` to `ValueDeserializer<String>` | Jackson 3 renamed the base class. |
| Drop explicit `JavaTimeModule` registration | Jackson 3 bundles `java.time` support directly inside `jackson-databind` (`tools.jackson.databind.ext.javatime`); there is no separate `tools.jackson.datatype.jsr310` artifact. |
| Repackage `ObjectMapper` imports in `AbstractControllerIT`, `AcspMongoRepositoryIT`, `EmptyFieldDeserializerTest` | After the port, only a Jackson 3 `JsonMapper` bean is published. `@Autowired ObjectMapper` still resolves via `JsonMapper extends ObjectMapper`, but the imports need to point at the Jackson 3 type. |
| Remove stray trailing comma in `EmptyFieldDeserializerTest` JSON fixture | Jackson 2 silently stopped reading at the closing brace; Jackson 3's `_verifyNoTrailingTokens` correctly rejects it. The fixture was always malformed JSON. |
| Pin `tomcat-embed-core`, `tomcat-embed-el`, `tomcat-embed-websocket` to `${tomcat.version}` = `11.0.22` via explicit `<dependencyManagement>` entries | Override the SB 4.0.6 BOM-managed Tomcat to clear the six CVEs above. A `<tomcat.version>` property override alone has no effect on a BOM imported with `<scope>import</scope>` — that only works with parent inheritance — so the override has to be direct `<dependencyManagement>` entries, one per artifact. Marked with a code comment so the whole block gets removed once a SB 4.0.x patch ships a fixed `tomcat-embed-*`. |

Model `@JsonProperty` annotations stay on `com.fasterxml.jackson.annotation.*` — Jackson 3 still reads the Jackson 2 annotation artifact, which is on the classpath transitively at `2.21`.

### Related Jira tickets
[ASM-1074](https://companieshouse.atlassian.net/browse/ASM-1074)

## Developer check list
### General
- [x] Is the PR as small as it can be?
- [x] Has the code been double-checked against `main`? — branched from `origin/main`
- [x] Has the `POM` been updated for the latest versions of dependencies? — `tomcat-embed-*` pinned to 11.0.22 via dependencyManagement override; to be removed once SB ships a fixed BOM
- [x] Is the `README` up to date? — no impact
- [ ] Does the code adhere to standards in this repository, including SonarQube checks?
- [ ] Has the Jira ticket been updated with any relevant comments?

### Configuration
- [x] Are any configuration changes required in `docker-chs-development`? — None
- [x] Have new env vars been added to `ecs-service-configs-dev`? — None

### Testing
- [x] Do the code changes have unit and integration tests with code coverage > 80%? — existing IT/UT cover the affected paths; behavioural fix is response-shape, validated by karate
- [ ] Has the code been tested locally and/or passed the API Karate tests locally? — **handed to tester to verify in their environment**
- [ ] Have mandatory manual test cases been run?

## Notes to the tester

Please re-run the karate suite that was failing on `main` after #27:

```
mvn test -Dkarate.options="--tags @acsp-profile" -Dkarate.env=cidev
```

The previously-failing assertions in `acsp_get_full_profile.feature:87` (and `:191`) were of the form:

```
actual has 3 more key(s) than expected - {deauthorised_from:null, etag:null, notified_from:null}
```

After this fix those keys should no longer be serialized into the response, and the `match response == expectedGetResponse` should pass for all `acsp_type` rows.

> **Heads-up:** the sibling [`acsp-profile-delta-consumer`](https://github.com/companieshouse/acsp-profile-delta-consumer) likely has the same latent bug if it also picked up Spring Boot 4 and declares an `@Primary com.fasterxml.jackson.databind.ObjectMapper` bean, **and** the same `tomcat-embed-*` 11.0.21 CVE blocker on its pipeline. Worth auditing as a follow-up.

[ASM-1074]: https://companieshouse.atlassian.net/browse/ASM-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ